### PR TITLE
Set Debug logging to off

### DIFF
--- a/cogs/src/common.py
+++ b/cogs/src/common.py
@@ -1,5 +1,5 @@
 # Print debug verbose messages
-DEBUG = True
+DEBUG = False
 
 # Use color while logging
 USE_COLOR = True


### PR DESCRIPTION
The new contributing.md talks about setting DEBUG (in common.py) to True for development. Yet, it's already set to True by default. This PR changes it to be False for new users.