### PR TITLE
FIX: V3ntus/repo-finder-bot#8 discord.py was not logging correctly

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,14 +11,18 @@ from discord_slash import SlashCommand
 from dotenv import load_dotenv
 
 from utils import logutil
-from utils.common import DEBUG
+from utils.common import DEBUG, DEBUG_DISCORD
 
 load_dotenv()
 
 # Configure logging for this (main.py) handler
 logger = logutil.initLogger("main.py")
 
-logger.warning(f"Debug mode is {DEBUG}")
+# Configure logging for discord.py
+if DEBUG:
+    logging = logutil.getLogger("discord")
+
+logger.warning(f"Debug mode is {DEBUG} || Discord debug mode is {DEBUG_DISCORD}")
 
 DEV_GUILD = int(os.environ.get("DEV_GUILD"))
 TOKEN = os.environ.get("TOKEN")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord_py_slash_command==3.0.1
+discord-py-interactions==3.0.2
 discord.py==1.7.3
 requests==2.26.0
 discord==1.7.3

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,5 +1,8 @@
 # Print debug verbose messages
 DEBUG = False
 
+# Print discord.py verbose/debug messages
+DEBUG_DISCORD = False
+
 # Use color while logging
 USE_COLOR = True

--- a/utils/logutil.py
+++ b/utils/logutil.py
@@ -1,18 +1,34 @@
+"""
+Custom logging script
+"""
+
 import logging
 
-from .common import DEBUG
+from .common import DEBUG, DEBUG_DISCORD
 
+def getLogger(name):
+    """Function to get a logger
+    Useful for modules that have already initialized a logger, such as discord.py
+    """
+    __logger = logging.getLogger(name)
+    __logger.setLevel(logging.DEBUG if DEBUG_DISCORD else logging.INFO)
+    __ch = logging.StreamHandler()
+    __ch.setFormatter(CustomFormatter())
+    __logger.addHandler(__ch)
+    return __logger
 
 def initLogger(name="root"):
-    logger = logging.Logger(name)
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG if DEBUG else logging.INFO)
-    ch.setFormatter(CustomFormatter())
-    logger.addHandler(ch)
-    return logger
+    """Function to create a designated logger for separate modules"""
+    __logger = logging.Logger(name)
+    __ch = logging.StreamHandler()
+    __ch.setLevel(logging.DEBUG if DEBUG else logging.INFO)
+    __ch.setFormatter(CustomFormatter())
+    __logger.addHandler(__ch)
+    return __logger
 
 
 class CustomFormatter(logging.Formatter):
+    """Custom formatter class"""
     grey = "\x1b[38;1m"
     green = "\x1b[42;1m"
     yellow = "\x1b[43;1m"
@@ -20,21 +36,21 @@ class CustomFormatter(logging.Formatter):
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
 
-    format = f"[%(asctime)s][%(levelname)-7s][%(name)-14s][%(lineno)4s] %(message)s"
+    format = "[%(asctime)s][%(levelname)-7s][%(name)-14s][%(lineno)4s] %(message)s"
     FORMATS = {
         logging.DEBUG: green + f"{reset}[%(asctime)s]{green}[%(levelname)-7s][%(name)-14s]{reset}[{red}%(lineno)4s{reset}] %(message)s" + reset,
         logging.INFO: grey + f"{reset}[%(asctime)s]{grey}[%(levelname)-7s][%(name)-14s]{reset}[{red}%(lineno)4s{reset}] %(message)s" + reset,
         logging.WARNING: yellow + f"[%(asctime)s][%(levelname)-7s][%(name)-14s][{red}%(lineno)4s{reset}{yellow}] %(message)s" + reset,
-        logging.ERROR: red + f"[%(asctime)s][%(levelname)-7s][%(name)-14s][%(lineno)4s] %(message)s" + reset,
+        logging.ERROR: red + "[%(asctime)s][%(levelname)-7s][%(name)-14s][%(lineno)4s] %(message)s" + reset,
         logging.CRITICAL: bold_red +
-        f"[%(asctime)s][%(levelname)-7s][%(name)-14s][%(lineno)4s] %(message)s" + reset
+        "[%(asctime)s][%(levelname)-7s][%(name)-14s][%(lineno)4s] %(message)s" + reset
     } if DEBUG else {
         logging.DEBUG: reset,
-        logging.INFO: grey + f"[%(asctime)s][%(levelname)7s] %(message)s" + reset,
-        logging.WARNING: yellow + f"[%(asctime)s][%(levelname)7s] %(message)s" + reset,
-        logging.ERROR: red + f"[%(asctime)s][%(levelname)7s] %(message)s" + reset,
+        logging.INFO: grey + "[%(asctime)s][%(levelname)7s] %(message)s" + reset,
+        logging.WARNING: yellow + "[%(asctime)s][%(levelname)7s] %(message)s" + reset,
+        logging.ERROR: red + "[%(asctime)s][%(levelname)7s] %(message)s" + reset,
         logging.CRITICAL: bold_red +
-        f"[%(asctime)s][%(levelname)7s] %(message)s" + reset
+        "[%(asctime)s][%(levelname)7s] %(message)s" + reset
     }
     # Documenting my dwindling sanity here
 


### PR DESCRIPTION
https://github.com/savioxavier/repo-finder-bot/commit/9270addb7231211225a4a3f8d476938f1261f271 :
- Discord.py will now adhere to the custom logger format and show proper log messages
- Added `DEBUG_DISCORD` to toggle verbose Discord.py debug messages on or off

https://github.com/savioxavier/repo-finder-bot/commit/344158d3fa562e0bbb1c6a270f7883160f8c5c74 :
- Incoming deprecation of old library as of goverfl0w/discord-interactions@0b43e5f. This migration *shouldn't* break anything in this version, but 4.x will